### PR TITLE
[Qt] rework banlist signal handling to be much easier

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -210,12 +210,6 @@ QString ClientModel::formatClientStartupTime() const
     return QDateTime::fromTime_t(nClientStartupTime).toString();
 }
 
-void ClientModel::updateBanlist()
-{
-    banTableModel->refresh();
-    emit banListChanged();
-}
-
 // Handlers for core signals
 static void ShowProgress(ClientModel *clientmodel, const std::string &title, int nProgress)
 {
@@ -240,19 +234,12 @@ static void NotifyAlertChanged(ClientModel *clientmodel, const uint256 &hash, Ch
                               Q_ARG(int, status));
 }
 
-static void BannedListChanged(ClientModel *clientmodel)
-{
-    qDebug() << QString("%1: Requesting update for peer banlist").arg(__func__);
-    QMetaObject::invokeMethod(clientmodel, "updateBanlist", Qt::QueuedConnection);
-}
-
 void ClientModel::subscribeToCoreSignals()
 {
     // Connect signals to client
     uiInterface.ShowProgress.connect(boost::bind(ShowProgress, this, _1, _2));
     uiInterface.NotifyNumConnectionsChanged.connect(boost::bind(NotifyNumConnectionsChanged, this, _1));
     uiInterface.NotifyAlertChanged.connect(boost::bind(NotifyAlertChanged, this, _1, _2));
-    uiInterface.BannedListChanged.connect(boost::bind(BannedListChanged, this));
 }
 
 void ClientModel::unsubscribeFromCoreSignals()
@@ -261,5 +248,4 @@ void ClientModel::unsubscribeFromCoreSignals()
     uiInterface.ShowProgress.disconnect(boost::bind(ShowProgress, this, _1, _2));
     uiInterface.NotifyNumConnectionsChanged.disconnect(boost::bind(NotifyNumConnectionsChanged, this, _1));
     uiInterface.NotifyAlertChanged.disconnect(boost::bind(NotifyAlertChanged, this, _1, _2));
-    uiInterface.BannedListChanged.disconnect(boost::bind(BannedListChanged, this));
 }

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -90,7 +90,6 @@ signals:
     void numBlocksChanged(int count, const QDateTime& blockDate);
     void alertsChanged(const QString &warnings);
     void bytesChanged(quint64 totalBytesIn, quint64 totalBytesOut);
-    void banListChanged();
 
     //! Fired when a message should be reported to the user
     void message(const QString &title, const QString &message, unsigned int style);
@@ -102,7 +101,6 @@ public slots:
     void updateTimer();
     void updateNumConnections(int numConnections);
     void updateAlert(const QString &hash, int status);
-    void updateBanlist();
 };
 
 #endif // BITCOIN_QT_CLIENTMODEL_H

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -64,6 +64,8 @@ private slots:
     void showBanTableContextMenu(const QPoint& point);
     /** Hides ban table if no bans are present */
     void showOrHideBanTableIfRequired();
+    /** clear the selected node */
+    void clearSelectedNode();
 
 public slots:
     void clear();
@@ -98,8 +100,6 @@ private:
     void setTrafficGraphRange(int mins);
     /** show detailed information on ui about selected node */
     void updateNodeDetail(const CNodeCombinedStats *stats);
-    /** clear the selected node */
-    void clearSelectedNode();
 
     enum ColumnWidths
     {

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -528,7 +528,6 @@ UniValue setban(const UniValue& params, bool fHelp)
             throw JSONRPCError(RPC_MISC_ERROR, "Error: Unban failed");
     }
 
-    uiInterface.BannedListChanged();
     return NullUniValue;
 }
 
@@ -570,7 +569,6 @@ UniValue clearbanned(const UniValue& params, bool fHelp)
                             );
 
     CNode::ClearBanned();
-    uiInterface.BannedListChanged();
 
     return NullUniValue;
 }

--- a/src/ui_interface.h
+++ b/src/ui_interface.h
@@ -95,9 +95,6 @@ public:
 
     /** New block has been accepted */
     boost::signals2::signal<void (const uint256& hash)> NotifyBlockTip;
-
-    /** Banlist did change. */
-    boost::signals2::signal<void (void)> BannedListChanged;
 };
 
 extern CClientUIInterface uiInterface;


### PR DESCRIPTION
- fix auto refresh of bantable model (add missung startAutoRefresh and
  stopAutoRefresh)
- as we pull the list from the core via a timer, there is no need to add
  any core signals
- this also removes the need to rely on client model to update the
  bantable modle, which allows for further simplifications

- also fix clearing peer detail window, when selecting (clicking) peers in the
  ban list